### PR TITLE
Find Embree according to OS

### DIFF
--- a/cmake/FindEmbree.cmake
+++ b/cmake/FindEmbree.cmake
@@ -4,13 +4,22 @@ find_path(EMBREE_INCLUDE_PATH embree3/rtcore.h
   /usr/local/include
   /opt/local/include)
 
-find_library(EMBREE_LIBRARY NAMES embree3 PATHS 
-  ${CMAKE_SOURCE_DIR}/embree/lib-linux
+if (APPLE)
+find_library(EMBREE_LIBRARY NAMES embree3 PATHS
   ${CMAKE_SOURCE_DIR}/embree/lib-macos
-  ${CMAKE_SOURCE_DIR}/embree/lib-win32
-  /usr/lib 
-  /usr/local/lib 
+  /usr/lib
+  /usr/local/lib
   /opt/local/lib)
+elseif (WIN32)
+find_library(EMBREE_LIBRARY NAMES embree3 PATHS
+  ${CMAKE_SOURCE_DIR}/embree/lib-win32)
+else ()
+find_library(EMBREE_LIBRARY NAMES embree3 PATHS
+  ${CMAKE_SOURCE_DIR}/embree/lib-linux
+  /usr/lib
+  /usr/local/lib
+  /opt/local/lib)
+endif ()
 
 if (EMBREE_INCLUDE_PATH AND EMBREE_LIBRARY)
   set(EMBREE_FOUND TRUE)


### PR DESCRIPTION
Fixes #1 
guard `find_library` with OS flag so correct Embree can be found, tested on macOS and ubuntu 20.04