### PR TITLE
Fixed unused variable warning.

### DIFF
--- a/src/tests/matrix.cpp
+++ b/src/tests/matrix.cpp
@@ -10,7 +10,6 @@ int main(int argc, char *argv[]) {
     );
     Matrix4x4 m_inv = inverse(m);
     Matrix4x4 m_inv_m = m_inv * m;
-    int count = 1;
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
             Real target = i == j ? Real(1) : Real(0);
@@ -18,7 +17,6 @@ int main(int argc, char *argv[]) {
                 printf("FAIL\n");
                 return 1;
             }
-            count++;
         }
     }
 


### PR DESCRIPTION
When building lajolla on Mac M1, the following warning is found:

![image](https://github.com/BachiLi/lajolla_public/assets/879124/204ad743-23d1-4ad9-b6ac-e45c7db2c52c)