### PR TITLE
Added missing info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ If you are on Unix systems, try
 mkdir build
 cd build
 cmake ..
+cmake --build .
 ```
 It requires compilers that support C++17 (gcc version >= 8, clang version >= 7, Apple Clang version >= 11.0, MSVC version >= 19.14).
 
-Apple M1 users: you might need to build Embree from scratch since the prebuilt MacOS binary provided is built for x86 machines.
+Apple M1 users: you might need to build Embree from scratch since the prebuilt MacOS binary provided is built for x86 machines. (But try build command above first.)
 
 # Run
 Try 


### PR DESCRIPTION
Per subject. I required an extra build command to build on both Linux and Mac M1.  Also, currently builds fine on my M1 mac w/o building Embree.