### PR TITLE
Fixed simple_sphere.xml renders to all black on certain conditions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,14 +34,15 @@ int main(int argc, char *argv[]) {
         Timer timer;
         tick(timer);
         std::cout << "Parsing and constructing scene " << filename << "." << std::endl;
-        Scene scene = parse_scene(filename, embree_device);
+        Scene* scene = parse_scene(filename, embree_device);
         std::cout << "Done. Took " << tick(timer) << " seconds." << std::endl;
         std::cout << "Rendering..." << std::endl;
-        Image3 img = render(scene);
-        if (outputfile.compare("") == 0) {outputfile = scene.output_filename;}
+        Image3 img = render(*scene);
+        if (outputfile.compare("") == 0) {outputfile = scene->output_filename;}
         std::cout << "Done. Took " << tick(timer) << " seconds." << std::endl;
         imwrite(outputfile, img);
         std::cout << "Image written to " << outputfile << std::endl;
+        delete scene;
     }
 
     parallel_cleanup();

--- a/src/parsers/parse_scene.cpp
+++ b/src/parsers/parse_scene.cpp
@@ -1406,7 +1406,7 @@ Shape parse_shape(pugi::xml_node node,
     return shape;
 }
 
-Scene parse_scene(pugi::xml_node node, const RTCDevice &embree_device) {
+Scene* parse_scene(pugi::xml_node node, const RTCDevice &embree_device) {
     RenderOptions options;
     Camera camera(Matrix4x4::identity(),
                   c_default_fov,
@@ -1586,7 +1586,7 @@ Scene parse_scene(pugi::xml_node node, const RTCDevice &embree_device) {
             }
         }
     }
-    return Scene{embree_device,
+    return new Scene{embree_device,
                  camera,
                  materials,
                  shapes,
@@ -1598,7 +1598,7 @@ Scene parse_scene(pugi::xml_node node, const RTCDevice &embree_device) {
                  filename};
 }
 
-Scene parse_scene(const fs::path &filename, const RTCDevice &embree_device) {
+Scene* parse_scene(const fs::path &filename, const RTCDevice &embree_device) {
     pugi::xml_document doc;
     pugi::xml_parse_result result = doc.load_file(filename.c_str());
     if (!result) {
@@ -1609,7 +1609,7 @@ Scene parse_scene(const fs::path &filename, const RTCDevice &embree_device) {
     // back up the current working directory and switch to the parent folder of the file
     fs::path old_path = fs::current_path();
     fs::current_path(filename.parent_path());
-    Scene scene = parse_scene(doc.child("scene"), embree_device);
+    Scene* scene = parse_scene(doc.child("scene"), embree_device);
     // switch back to the old current working directory
     fs::current_path(old_path);
     return scene;

--- a/src/parsers/parse_scene.h
+++ b/src/parsers/parse_scene.h
@@ -6,4 +6,4 @@
 #include <memory>
 
 /// Parse Mitsuba's XML scene format.
-Scene parse_scene(const fs::path &filename, const RTCDevice &embree_device);
+Scene* parse_scene(const fs::path &filename, const RTCDevice &embree_device);


### PR DESCRIPTION
# Summary of changes
I have changed the declaration of the scene struct from parse_scene to return a pointer to the struct and ensure the same shape vector in the struct persist after the parse_scene function returns to eliminate the memory issues that cause simple_sphere to not render.

## Details
Specifically, the memory issue was that the ADDRESS of the shape vector from the initial scene struct in parse_scene is sent to the RTC_Device to render the spheres. However, that part of stack memory was INVALIDATED after the function return from parse_scene to main and the scene struct in main is just a COPY of the scene struct from parse_scene. This means the memory of initial scene struct is going to be overwritten by new data passed to the stack, and unfortunately, the shape vector was also overwritten. 

#### Why does this have to do with the scene rendering all black? 
When the shape vector was overwritten, the sphere structs constructed in simple_sphere.xml in the shape vector would contain random values. On my local system (I have suffered from the black simple sphere as well), the positions of both of the spheres were set to (-1.45682e+144, -1.45682e+144, -1.45682e+144), which is near infinitely far. As a result, none of the spheres show up in the camera view.

#### Why aren't there significant problems with other scene renders? 
I suspect that is due to the large sizes of other variables from the more complicated scenes such that the addresses of the shape vector were low enough in the stack to not be overwritten by any other stack variables. Other variables from the scene struct seems to not suffer from the same issue because they are used by value instead of pointer address. As a result, it seems to me that the simplicity of the simple_sphere scene was the difference that prevent it from working. 

#### How does my fix solve the issue?
My fix is to change the scene creation to a pointer to a struct in heap and deallocate it after we render the scene, which should protect the address of the shape vector from being overwritten by other data and corrupting. RTC_device should correctly evaluate the sphere vector and compute with the correct information like positions of sphere. I hope this will also prevent some potential symptoms of failing renders from appearing in the future.

### Disclaimer
All the text was written with my personal understanding of the code, and the fix was confirmed to work by me and myself only. It addresses a bug that has affected me personally, although I have also seen some cases of black render with simple_sphere on the course Piazza as well. Attached below is the comparison of my renders before and after the fix.

[simple_sphere_render_comparisons.zip](https://github.com/BachiLi/lajolla_public/files/14227400/simple_sphere_render_comparisons.zip)