### PR TITLE
Fix XML Files

### DIFF
--- a/scenes/volpath_test/vol_cbox_teapot.xml
+++ b/scenes/volpath_test/vol_cbox_teapot.xml
@@ -3,7 +3,7 @@
 <scene version="0.5.0">
 	<integrator type="volpath">
 		<integer name="maxDepth" value="-1"/>
-		<integer name="version" value="6"/>
+		<integer name="version" value="5"/>
 	</integrator>
 
 	<medium type="homogeneous" id="medium">

--- a/scenes/volpath_test/volpath_test5_2.xml
+++ b/scenes/volpath_test/volpath_test5_2.xml
@@ -9,7 +9,7 @@
 	<medium type="homogeneous" id="medium">
 		<rgb name="sigmaA" value="1.0 1.0 1.0"/>
 		<rgb name="sigmaS" value="0.5 0.5 0.5"/>
-		<float name="scale" value="200"/>
+		<float name="scale" value="2"/>
 	</medium>
 
 	<shape type="sphere">
@@ -22,6 +22,17 @@
 			<float name="intIOR" value="1.33"/>
 			<!-- <float name="roughness" value="0.316"/> -->
 			<float name="alpha" value="0.1"/>
+		</bsdf>
+	</shape>
+
+	<shape type="sphere">
+		<point name="center" x="0" y="0" z="0"/>
+		<float name="radius" value="0.7"/>
+
+		<ref name="exterior" id="medium"/>
+
+		<bsdf type="diffuse">
+			<rgb name="reflectance" value="0.9 0.2 0.2"/>
 		</bsdf>
 	</shape>
 


### PR DESCRIPTION
Fixes:

1) The ``vol_cbox_teapot`` scene currently uses version 6 of the volpath integrator, but the HW spec requests it to be rendered with version 5.
2) The ``volpath_test5_2`` scene is missing an inner Lambertian sphere as described in the spec.